### PR TITLE
feat(s3, ui): 实现S3文件夹管理与UI风格统一

### DIFF
--- a/src/app/api/s3/folders/route.ts
+++ b/src/app/api/s3/folders/route.ts
@@ -1,0 +1,154 @@
+import { S3Client, PutObjectCommand, DeleteObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import jwt, { JwtPayload } from "jsonwebtoken";
+
+export const runtime = "nodejs";
+
+const AWS_REGION = process.env.AWS_REGION;
+const S3_BUCKET_NAME = process.env.S3_BUCKET_NAME;
+const USE_ACCELERATE = process.env.S3_ACCELERATE === "1";
+
+function createS3Client(): S3Client {
+  const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+  let requestHandler: NodeHttpHandler | undefined;
+  if (proxy) {
+    const agent = new HttpsProxyAgent(proxy);
+    requestHandler = new NodeHttpHandler({
+      httpAgent: agent,
+      httpsAgent: agent,
+      connectionTimeout: 5000,
+      socketTimeout: 15000,
+    });
+  } else {
+    requestHandler = new NodeHttpHandler({
+      connectionTimeout: 5000,
+      socketTimeout: 15000,
+    });
+  }
+
+  return new S3Client({
+    region: AWS_REGION,
+    requestHandler,
+    useAccelerateEndpoint: USE_ACCELERATE,
+  });
+}
+
+const s3Client = createS3Client();
+
+export async function POST(request: Request) {
+  try {
+    if (!AWS_REGION || !S3_BUCKET_NAME) {
+      return new Response(
+        JSON.stringify({ error: "Missing AWS_REGION or S3_BUCKET_NAME env" }),
+        { status: 500 }
+      );
+    }
+
+    const auth = request.headers.get("authorization") || request.headers.get("Authorization") || "";
+    const bearer = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+    const secret = process.env.AUTH_JWT_SECRET || process.env.JWT_SECRET || "dev-secret";
+    let userId: string | null = null;
+    try {
+      if (bearer) {
+        const decoded = jwt.verify(bearer, secret) as JwtPayload & { sub?: string };
+        userId = decoded?.sub ? String(decoded.sub) : null;
+      }
+    } catch { }
+    if (!userId) {
+      return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
+    }
+
+    const body = await request.json();
+    const { path, folderName } = body;
+
+    if (!folderName) {
+      return new Response(JSON.stringify({ error: "folderName is required" }), { status: 400 });
+    }
+
+    const basePrefix = `uploads/users/${userId}/videos/`;
+    const currentPrefix = path ? `${basePrefix}${path}` : basePrefix;
+    const key = `${currentPrefix}${folderName}/`;
+
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: S3_BUCKET_NAME,
+        Key: key,
+        Body: "",
+      })
+    );
+
+    return Response.json({ success: true, key });
+
+  } catch (error: unknown) {
+    console.error("[folders][POST] error", error);
+    const message = error instanceof Error ? error.message : "Failed to create folder";
+    return new Response(
+      JSON.stringify({ error: message }),
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    if (!AWS_REGION || !S3_BUCKET_NAME) {
+      return new Response(
+        JSON.stringify({ error: "Missing AWS_REGION or S3_BUCKET_NAME env" }),
+        { status: 500 }
+      );
+    }
+
+    const auth = request.headers.get("authorization") || request.headers.get("Authorization") || "";
+    const bearer = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+    const secret = process.env.AUTH_JWT_SECRET || process.env.JWT_SECRET || "dev-secret";
+    let userId: string | null = null;
+    try {
+      if (bearer) {
+        const decoded = jwt.verify(bearer, secret) as JwtPayload & { sub?: string };
+        userId = decoded?.sub ? String(decoded.sub) : null;
+      }
+    } catch { }
+    if (!userId) {
+      return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const prefix = searchParams.get("prefix");
+
+    if (!prefix) {
+      return new Response(JSON.stringify({ error: "prefix is required" }), { status: 400 });
+    }
+
+    // For safety, only allow deleting empty folders first.
+    // To delete a non-empty folder, you would need to list and delete all objects within it first.
+    const listRes = await s3Client.send(
+      new ListObjectsV2Command({
+        Bucket: S3_BUCKET_NAME,
+        Prefix: prefix,
+        MaxKeys: 2, // Check if there's more than just the folder placeholder itself
+      })
+    );
+
+    if (listRes.Contents && listRes.Contents.length > 1) {
+        return new Response(JSON.stringify({ error: "Folder is not empty" }), { status: 400 });
+    }
+
+    await s3Client.send(
+      new DeleteObjectCommand({
+        Bucket: S3_BUCKET_NAME,
+        Key: prefix,
+      })
+    );
+
+    return Response.json({ success: true });
+
+  } catch (error: unknown) {
+    console.error("[folders][POST] error", error);
+    const message = error instanceof Error ? error.message : "Failed to create folder";
+    return new Response(
+      JSON.stringify({ error: message }),
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/s3/move/route.ts
+++ b/src/app/api/s3/move/route.ts
@@ -1,0 +1,133 @@
+import { S3Client, CopyObjectCommand, DeleteObjectCommand, ListObjectsV2Command, DeleteObjectsCommand } from "@aws-sdk/client-s3";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import jwt, { JwtPayload } from "jsonwebtoken";
+
+export const runtime = "nodejs";
+
+const AWS_REGION = process.env.AWS_REGION;
+const S3_BUCKET_NAME = process.env.S3_BUCKET_NAME;
+const USE_ACCELERATE = process.env.S3_ACCELERATE === "1";
+
+const agent = process.env.HTTPS_PROXY ? new HttpsProxyAgent(process.env.HTTPS_PROXY) : undefined;
+
+const s3Client = new S3Client({
+  region: AWS_REGION,
+  useAccelerateEndpoint: USE_ACCELERATE,
+  ...(agent && { requestHandler: new NodeHttpHandler({ httpAgent: agent, httpsAgent: agent }) }),
+});
+
+// Helper function to move a single object
+async function moveObject(sourceKey: string, destKey: string) {
+  if (!S3_BUCKET_NAME) throw new Error("S3_BUCKET_NAME is not set");
+  await s3Client.send(new CopyObjectCommand({
+    Bucket: S3_BUCKET_NAME,
+    CopySource: `${S3_BUCKET_NAME}/${sourceKey}`,
+    Key: destKey,
+  }));
+  await s3Client.send(new DeleteObjectCommand({
+    Bucket: S3_BUCKET_NAME,
+    Key: sourceKey,
+  }));
+}
+
+// Helper function to move a directory (prefix)
+async function moveDirectory(sourcePrefix: string, destPrefix: string) {
+  if (!S3_BUCKET_NAME) throw new Error("S3_BUCKET_NAME is not set");
+
+  const listRes = await s3Client.send(new ListObjectsV2Command({
+    Bucket: S3_BUCKET_NAME,
+    Prefix: sourcePrefix,
+  }));
+
+  if (!listRes.Contents || listRes.Contents.length === 0) return; // Nothing to move
+
+  const moves = listRes.Contents.map(obj => {
+    const sourceKey = obj.Key!;
+    const destKey = destPrefix + sourceKey.substring(sourcePrefix.length);
+    return moveObject(sourceKey, destKey);
+  });
+
+  await Promise.all(moves);
+}
+
+export async function POST(request: Request) {
+  try {
+    if (!AWS_REGION || !S3_BUCKET_NAME) {
+      return new Response(JSON.stringify({ error: "Missing AWS_REGION or S3_BUCKET_NAME env" }), { status: 500 });
+    }
+
+    const auth = request.headers.get("authorization") || "";
+    const bearer = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+    const secret = process.env.AUTH_JWT_SECRET || process.env.JWT_SECRET || "dev-secret";
+    let userId: string | null = null;
+    try {
+      if (bearer) {
+        const decoded = jwt.verify(bearer, secret) as JwtPayload & { sub?: string };
+        userId = decoded?.sub ? String(decoded.sub) : null;
+      }
+    } catch { }
+    if (!userId) {
+      return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
+    }
+
+    const { sourceKey, destinationPrefix } = await request.json();
+    if (!sourceKey || destinationPrefix === undefined) {
+      return new Response(JSON.stringify({ error: "sourceKey and destinationPrefix are required" }), { status: 400 });
+    }
+
+    const userVideosPrefix = `uploads/users/${userId}/videos/`;
+    if (!sourceKey.startsWith(userVideosPrefix)) {
+        return new Response(JSON.stringify({ error: "Invalid source key" }), { status: 403 });
+    }
+
+    const fileName = sourceKey.split('/').pop();
+    const destKey = `${destinationPrefix}${fileName}`;
+
+    // 1. Move the main video file
+    await moveObject(sourceKey, destKey);
+
+    // 2. Move associated files
+    const baseKey = fileName.replace(/\.[^/.]+$/, "");
+    const derivedPrefixes = {
+        hls: `uploads/users/${userId}/hls/`,
+        thumbs: `uploads/users/${userId}/thumbs/`,
+        preview: `uploads/users/${userId}/preview/`,
+    };
+
+    // Move HLS directory
+    await moveDirectory(`${derivedPrefixes.hls}${baseKey}/`, `${derivedPrefixes.hls}${destinationPrefix.substring(userVideosPrefix.length)}${baseKey}/`);
+
+    // Move other derived files (previews, thumbs)
+    const associatedExtensions = [
+        ".jpg", // poster
+        ".480p.mp4", // preview
+        ".360p.mp4", // preview
+        ".anim.webp", // animated preview
+        ".sprite.vtt", ".sprite.jpg", // vtt sprites
+        ".frames.vtt", ".frames.jpg" // vtt frames
+    ];
+
+    const movePromises: Promise<void>[] = [];
+
+    for (const ext of associatedExtensions) {
+        const fromKey = `${baseKey}${ext}`;
+        const newToKey = `${destinationPrefix.substring(userVideosPrefix.length)}${baseKey}${ext}`;
+        
+        if (ext.includes('p.mp4') || ext.includes('.webp')) { // Previews
+            movePromises.push(moveObject(`${derivedPrefixes.preview}${fromKey}`, `${derivedPrefixes.preview}${newToKey}`));
+        } else { // Thumbs
+            movePromises.push(moveObject(`${derivedPrefixes.thumbs}${fromKey}`, `${derivedPrefixes.thumbs}${newToKey}`));
+        }
+    }
+
+    await Promise.all(movePromises);
+
+    return Response.json({ success: true, newKey: destKey });
+
+  } catch (error: unknown) {
+    console.error("[move][POST] error", error);
+    const message = error instanceof Error ? error.message : "Failed to move file";
+    return new Response(JSON.stringify({ error: message }), { status: 500 });
+  }
+}

--- a/src/app/components/VideoGallery.tsx
+++ b/src/app/components/VideoGallery.tsx
@@ -6,6 +6,11 @@ import HoverVideo from "@/app/components/HoverVideo";
 
 // 类型定义
 
+type FolderItem = {
+  name: string;
+  prefix: string;
+};
+
 type VideoItem = {
   key: string;
   url: string;
@@ -20,7 +25,8 @@ type VideoItem = {
 };
 
 export type ListResponse = {
-  items: VideoItem[];
+  folders: FolderItem[];
+  files: VideoItem[];
   nextToken: string | null;
   expires: number;
 };
@@ -30,12 +36,39 @@ type VideoGalleryProps = {
 };
 
 export default function VideoGallery({ listLoader }: VideoGalleryProps) {
-  const [items, setItems] = useState<VideoItem[]>([]);
+  const [folders, setFolders] = useState<FolderItem[]>([]);
+  const [files, setFiles] = useState<VideoItem[]>([]);
+  const [currentPath, setCurrentPath] = useState<string>("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [nextToken, setNextToken] = useState<string | null>(null);
   const [expires, setExpires] = useState<number>(600);
   const [openedKey, setOpenedKey] = useState<string | null>(null);
+  const [showCreateFolder, setShowCreateFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState("");
+  const [folderToDelete, setFolderToDelete] = useState<FolderItem | null>(null);
+  const [videoToMove, setVideoToMove] = useState<VideoItem | null>(null);
+
+  const breadcrumbs = useMemo(() => {
+    if (!currentPath) return [];
+    const parts = currentPath.split("/").filter(p => p);
+    return parts.map((part, i) => {
+      const path = parts.slice(0, i + 1).join("/") + "/";
+      return { name: part, path };
+    });
+  }, [currentPath]);
+
+  const moveTargetFolders = useMemo(() => {
+    const options: { name: string, prefix: string }[] = [];
+    // Add parent directory option if not in root
+    if (currentPath) {
+      const parentPath = currentPath.split('/').slice(0, -2).join('/') + '/';
+      options.push({ name: "../ (Parent Folder)", prefix: parentPath });
+    }
+    // Add current level folders
+    folders.forEach(f => options.push({ name: f.name, prefix: f.prefix }));
+    return options;
+  }, [folders, currentPath]);
 
   // 预览策略：auto/360/480；帧预览：auto/sprite/frame
   const [previewStrategy, setPreviewStrategy] = useState<"auto" | "360" | "480">("auto");
@@ -43,13 +76,14 @@ export default function VideoGallery({ listLoader }: VideoGalleryProps) {
 
   const limit = useMemo(() => 12, []);
 
-  async function load(token?: string | null) {
+  async function load(path: string, token?: string | null) {
     setLoading(true);
     setError(null);
     try {
       if (listLoader) {
         const data = await listLoader(token ?? null, limit);
-        setItems((prev) => (token ? [...prev, ...data.items] : data.items));
+        setFolders(token ? (prev) => [...prev, ...data.folders] : data.folders);
+        setFiles(token ? (prev) => [...prev, ...data.files] : data.files);
         setNextToken(data.nextToken);
         setExpires(data.expires ?? 600);
       } else {
@@ -58,12 +92,14 @@ export default function VideoGallery({ listLoader }: VideoGalleryProps) {
         url.searchParams.set("expires", "600");
         url.searchParams.set("includeHls", "1");
         if (token) url.searchParams.set("token", token);
+        if (path) url.searchParams.set("path", path);
 
         const jwt = localStorage.getItem("token") || "";
         const res = await fetch(url.toString(), { cache: "no-store", headers: jwt ? { Authorization: `Bearer ${jwt}` } : undefined });
         if (!res.ok) throw new Error(await res.text());
         const data = (await res.json()) as ListResponse;
-        setItems((prev) => (token ? [...prev, ...data.items] : data.items));
+        setFolders(token ? (prev) => [...prev, ...data.folders] : data.folders);
+        setFiles(token ? (prev) => [...prev, ...data.files] : data.files);
         setNextToken(data.nextToken);
         setExpires(data.expires ?? 600);
       }
@@ -75,14 +111,94 @@ export default function VideoGallery({ listLoader }: VideoGalleryProps) {
     }
   }
 
-  useEffect(() => { load(null); }, []);
+  useEffect(() => { load(currentPath, null); }, [currentPath]);
+
+  function handlePathChange(newPath: string) {
+    setCurrentPath(newPath);
+    setFolders([]);
+    setFiles([]);
+    setNextToken(null);
+  }
+
+  async function handleCreateFolder() {
+    if (!newFolderName) return;
+    setLoading(true);
+    try {
+      const jwt = localStorage.getItem("token") || "";
+      const res = await fetch("/api/s3/folders", {
+        method: "POST",
+        headers: { 
+          "Content-Type": "application/json",
+          ...(jwt && { Authorization: `Bearer ${jwt}` })
+        },
+        body: JSON.stringify({ path: currentPath, folderName: newFolderName }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setShowCreateFolder(false);
+      setNewFolderName("");
+      load(currentPath, null); // Refresh
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "创建失败";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDeleteFolder() {
+    if (!folderToDelete) return;
+    setLoading(true);
+    try {
+      const jwt = localStorage.getItem("token") || "";
+      const url = new URL("/api/s3/folders", window.location.origin);
+      url.searchParams.set("prefix", folderToDelete.prefix);
+      const res = await fetch(url.toString(), {
+        method: "DELETE",
+        headers: {
+          ...(jwt && { Authorization: `Bearer ${jwt}` })
+        }
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setFolderToDelete(null);
+      load(currentPath, null); // Refresh
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "删除失败";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleMoveVideo(destinationPrefix: string) {
+    if (!videoToMove) return;
+    setLoading(true);
+    try {
+      const jwt = localStorage.getItem("token") || "";
+      const res = await fetch("/api/s3/move", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(jwt && { Authorization: `Bearer ${jwt}` })
+        },
+        body: JSON.stringify({ sourceKey: videoToMove.key, destinationPrefix }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setVideoToMove(null);
+      load(currentPath, null); // Refresh
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "移动失败";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
 
   // 手动轻量预取：对首屏前三个用 Range 拉取前 64KB
   useEffect(() => {
     const controller = new AbortController();
     (async () => {
       try {
-        const first = items.slice(0, 3);
+        const first = files.slice(0, 3);
         await Promise.all(first.map(async (it) => {
           const fallback = `/api/s3/proxy?key=${encodeURIComponent(it.key)}&expires=600`;
           const href = it.preview360Url || it.previewUrl || fallback;
@@ -91,49 +207,147 @@ export default function VideoGallery({ listLoader }: VideoGalleryProps) {
       } catch { }
     })();
     return () => controller.abort();
-  }, [items]);
+  }, [files]);
 
   const prefetchCount = 6;
 
   return (
     <section style={{ marginTop: 24 }}>
+      <div style={{ marginBottom: 12 }}>
+        <nav aria-label="breadcrumb" style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 14 }}>
+          <button onClick={() => handlePathChange("")} style={{ cursor: "pointer", background: "none", border: "none", color: "black", textDecoration: "underline", fontFamily: 'monospace' }}>Home</button>
+          {breadcrumbs.map(crumb => (
+            <span key={crumb.path} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ fontFamily: 'monospace' }}>/</span>
+              <button onClick={() => handlePathChange(crumb.path)} style={{ cursor: "pointer", background: "none", border: "none", color: "black", textDecoration: "underline", fontFamily: 'monospace' }}>{crumb.name}</button>
+            </span>
+          ))}
+        </nav>
+      </div>
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
         <h2 style={{ fontSize: 18, fontWeight: 600 }}>已上传视频</h2>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <label htmlFor="sel-quality" style={{ fontSize: 12, color: "#6b7280" }}>预览清晰度</label>
-          <select id="sel-quality" value={previewStrategy} onChange={(e) => setPreviewStrategy(e.target.value as "auto" | "360" | "480")} style={{ padding: "2px 6px", borderRadius: 6 }}>
+          <label htmlFor="sel-quality" style={{ fontSize: 12, fontFamily: 'monospace' }}>预览清晰度</label>
+          <select id="sel-quality" value={previewStrategy} onChange={(e) => setPreviewStrategy(e.target.value as "auto" | "360" | "480")} style={{ padding: "2px 6px", border: "1px solid black", background: 'white' }}>
             <option value="auto">自动</option>
             <option value="360">360p</option>
             <option value="480">480p</option>
           </select>
-          <label htmlFor="sel-vtt" style={{ fontSize: 12, color: "#6b7280" }}>帧预览</label>
-          <select id="sel-vtt" value={vttMode} onChange={(e) => setVttMode(e.target.value as "auto" | "sprite" | "frame")} style={{ padding: "2px 6px", borderRadius: 6 }}>
+          <label htmlFor="sel-vtt" style={{ fontSize: 12, fontFamily: 'monospace' }}>帧预览</label>
+          <select id="sel-vtt" value={vttMode} onChange={(e) => setVttMode(e.target.value as "auto" | "sprite" | "frame")} style={{ padding: "2px 6px", border: "1px solid black", background: 'white' }}>
             <option value="auto">自动</option>
             <option value="sprite">雪碧图</option>
             <option value="frame">逐帧</option>
           </select>
-          <button onClick={() => load(null)} disabled={loading} style={{ background: "#f3f4f6", padding: "6px 10px", borderRadius: 6, cursor: loading ? "not-allowed" : "pointer" }}>刷新</button>
+          <button onClick={() => setShowCreateFolder(true)} style={{ background: "white", color: "black", border: "1px solid black", padding: "8px 12px", cursor: "pointer", boxShadow: "2px 2px 0px black" }}>
+            创建文件夹
+          </button>
+          <button onClick={() => load(currentPath, null)} disabled={loading} style={{ background: "white", color: "black", border: "1px solid black", padding: "6px 10px", cursor: loading ? "not-allowed" : "pointer", boxShadow: "2px 2px 0px black" }}>
+            刷新
+          </button>
         </div>
       </div>
 
-      {error && (<div style={{ marginTop: 8, color: "#991b1b" }}>{error}</div>)}
+      {error && (<div style={{ marginTop: 8, color: "red" }}>{error}</div>)}
+
+      {showCreateFolder && (
+        <div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, background: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000 }}>
+          <div style={{ background: "white", padding: 24, border: "2px solid black", boxShadow: "4px 4px 0px black", width: 400 }}>
+            <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 16, fontFamily: 'monospace' }}>创建新文件夹</h3>
+            <input 
+              type="text"
+              value={newFolderName}
+              onChange={(e) => setNewFolderName(e.target.value)}
+              placeholder="文件夹名称"
+              style={{ width: "100%", padding: 8, border: "1px solid black", marginBottom: 16, boxSizing: 'border-box', fontFamily: 'monospace' }}
+            />
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+              <button onClick={() => setShowCreateFolder(false)} style={{ background: "white", color: "black", border: "1px solid black", padding: "8px 12px", cursor: "pointer", boxShadow: "2px 2px 0px black" }}>
+                取消
+              </button>
+              <button onClick={handleCreateFolder} disabled={loading} style={{ background: "white", color: "black", border: "1px solid black", padding: "8px 12px", cursor: loading ? "not-allowed" : "pointer", boxShadow: "2px 2px 0px black" }}>
+                创建
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {folderToDelete && (
+        <div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, background: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000 }}>
+          <div style={{ background: "white", padding: 24, border: "2px solid black", boxShadow: "4px 4px 0px black", width: 400 }}>
+            <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 16, fontFamily: 'monospace' }}>确认删除</h3>
+            <p style={{ fontFamily: 'monospace' }}>你确定要删除文件夹 \"{folderToDelete.name}\" 吗？此操作无法撤销。</p>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
+              <button onClick={() => setFolderToDelete(null)} style={{ background: "white", color: "black", border: "1px solid black", padding: "8px 12px", cursor: "pointer", boxShadow: "2px 2px 0px black" }}>
+                取消
+              </button>
+              <button onClick={handleDeleteFolder} disabled={loading} style={{ background: "black", color: "white", border: "1px solid black", padding: "8px 12px", cursor: loading ? "not-allowed" : "pointer", boxShadow: "2px 2px 0px #555" }}>
+                删除
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {videoToMove && (
+        <div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, background: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000 }}>
+          <div style={{ background: "white", padding: 24, border: "2px solid black", boxShadow: "4px 4px 0px black", width: 400 }}>
+            <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 16, fontFamily: 'monospace' }}>移动视频</h3>
+            <p style={{ marginBottom: 8, fontFamily: 'monospace' }}>移动 \"{videoToMove.key.split('/').pop()}\" 到:</p>
+            <select 
+              id="move-dest-select"
+              style={{ width: "100%", padding: 8, border: "1px solid black", marginBottom: 16, boxSizing: 'border-box', background: 'white', fontFamily: 'monospace' }}
+              defaultValue={moveTargetFolders.length > 0 ? moveTargetFolders[0].prefix : ""}
+            >
+              {moveTargetFolders.map(f => <option key={f.prefix} value={f.prefix}>{f.name}</option>)}
+            </select>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+              <button onClick={() => setVideoToMove(null)} style={{ background: "white", color: "black", border: "1px solid black", padding: "8px 12px", cursor: "pointer", boxShadow: "2px 2px 0px black" }}>
+                取消
+              </button>
+              <button 
+                onClick={() => {
+                  const select = document.getElementById('move-dest-select') as HTMLSelectElement;
+                  handleMoveVideo(select.value);
+                }}
+                disabled={loading}
+                style={{ background: "white", color: "black", border: "1px solid black", padding: "8px 12px", cursor: loading ? "not-allowed" : "pointer", boxShadow: "2px 2px 0px black" }}
+              >
+                移动
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div style={{ height: 0, overflow: "hidden" }} aria-hidden>
-        {items.slice(0, prefetchCount).map((it) => {
+        {files.slice(0, prefetchCount).map((it) => {
           const fallback = `/api/s3/proxy?key=${encodeURIComponent(it.key)}&expires=600`;
           const preview = it.preview360Url || it.previewUrl || fallback;
           return <link key={it.key} rel="prefetch" href={preview} as="video" />;
         })}
       </div>
 
-      <div style={{ marginTop: 12, display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(480px, 1fr))", gap: 20 }}>
-        {items.map((it) => {
+      <div style={{ marginTop: 12, display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 20 }}>
+        {folders.map(folder => (
+          <div key={folder.prefix} style={{ position: "relative", border: "1px solid black", background: "white" }}>
+            <div onClick={() => handlePathChange(folder.prefix)} style={{ cursor: "pointer", padding: 16, display: "flex", alignItems: "center", gap: 12 }}>
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.22A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z"></path></svg>
+              <span style={{ fontFamily: 'monospace' }}>{folder.name}</span>
+            </div>
+            <button onClick={(e) => { e.stopPropagation(); setFolderToDelete(folder); }} style={{ position: "absolute", top: 8, right: 8, background: "white", border: "1px solid black", cursor: "pointer", padding: 4, boxShadow: "2px 2px 0px black" }}>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="black" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>
+            </button>
+          </div>
+        ))}
+        {files.map((it) => {
           const playing = openedKey === it.key;
           const fallback = `/api/s3/proxy?key=${encodeURIComponent(it.key)}&expires=600`;
           const preview480 = it.previewUrl || fallback;
           const preview360 = it.preview360Url || it.previewUrl || fallback;
           return (
-            <div key={it.key} style={{ position: "relative", borderRadius: 12, overflow: "hidden", background: "#000", aspectRatio: "16/9" }}>
+            <div key={it.key} style={{ position: "relative", overflow: "hidden", background: "#000", aspectRatio: "16/9", border: "1px solid black" }}>
               {playing ? (
                 <VideoPlayer
                   src={it.hlsUrl || it.url}
@@ -154,21 +368,31 @@ export default function VideoGallery({ listLoader }: VideoGalleryProps) {
                   }}
                 />
               ) : (
-                <HoverVideo
-                  src={it.url}
-                  previewSrc={preview480}
-                  preview360Src={preview360}
-                  animSrc={it.animUrl || undefined}
-                  thumbsBase={it.thumbsBase || undefined}
-                  poster={it.posterUrl || undefined}
-                  previewStrategy={previewStrategy}
-                  vttMode={vttMode}
-                  style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
-                  onClick={() => {
-                    const u = new URL(`/video/${encodeURIComponent(it.key)}`, window.location.origin);
-                    window.location.assign(u.toString());
-                  }}
-                />
+                <>
+                  <div style={{ position: "absolute", top: 8, right: 8, zIndex: 10, display: "flex", gap: 4 }}>
+                    <button 
+                      onClick={(e) => { e.stopPropagation(); setVideoToMove(it); }}
+                      style={{ background: "white", color: "black", border: "1px solid black", padding: "4px 8px", cursor: "pointer", boxShadow: "2px 2px 0px black" }}
+                    >
+                      移动
+                    </button>
+                  </div>
+                  <HoverVideo
+                    src={it.url}
+                    previewSrc={preview480}
+                    preview360Src={preview360}
+                    animSrc={it.animUrl || undefined}
+                    thumbsBase={it.thumbsBase || undefined}
+                    poster={it.posterUrl || undefined}
+                    previewStrategy={previewStrategy}
+                    vttMode={vttMode}
+                    style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
+                    onClick={() => {
+                      const u = new URL(`/video/${encodeURIComponent(it.key)}`, window.location.origin);
+                      window.location.assign(u.toString());
+                    }}
+                  />
+                </>
               )}
             </div>
           );
@@ -177,7 +401,7 @@ export default function VideoGallery({ listLoader }: VideoGalleryProps) {
 
       <div style={{ marginTop: 12, display: "flex", justifyContent: "center" }}>
         {nextToken && (
-          <button onClick={() => load(nextToken)} disabled={loading} style={{ background: "#111827", color: "white", padding: "8px 12px", borderRadius: 6, cursor: loading ? "not-allowed" : "pointer" }}>加载更多</button>
+          <button onClick={() => load(currentPath, nextToken)} disabled={loading} style={{ background: "white", color: "black", border: "1px solid black", padding: "8px 12px", cursor: loading ? "not-allowed" : "pointer", boxShadow: "2px 2px 0px black" }}>加载更多</button>
         )}
       </div>
     </section>


### PR DESCRIPTION
该提交引入了一整套功能，用于在基于S3的视频库中管理文件夹和移动视频，并为用户界面应用了全新的、统一的简笔画视觉风格。后端:- 实现了用于创建、删除和列出S3文件夹的API端点。- 实现了用于在文件夹之间移动视频及其关联资产（HLS、缩略图等）的API端点。- 修复了视频列表API中因前缀使用不当而导致文件夹内视频无法显示的错误。- 解决了S3的Delimiter被错误地应用于子查询，从而导致无法发现关联视频资产的问题。前端:- 添加了用于创建新文件夹、删除空文件夹以及在文件夹层级中导航的UI组件。- 实现了一个用于将视频移动到不同文件夹的模态对话框。- 为VideoGallery中的所有按钮、对话框和交互元素应用了统一的黑白、简笔画风格。- 修复了多个JSX语法错误并改进了组件结构。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Folder-based video library with breadcrumb navigation.
  * View folders and files separately in the gallery.
  * Create and delete folders directly from the UI.
  * Move videos (and related assets) to another folder.
  * “Load more” respects the current folder path.
* **Bug Fixes**
  * Prevents deletion of non-empty folders with clear messaging.
  * More robust error responses for invalid actions and authorization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->